### PR TITLE
Add Func instance for mut refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frunk_utils"
 authors = ["David Spies <dnspies@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Utilities for working with frunk."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,14 @@ pub trait Func<I> {
     fn call(&mut self, i: I) -> Self::Output;
 }
 
+impl<F: Func<I>, I> Func<I> for &mut F {
+    type Output = F::Output;
+
+    fn call(&mut self, i: I) -> Self::Output {
+        (*self).call(i)
+    }
+}
+
 impl<F: Func<Head>, Head, Tail: HMappable<Poly<F>>> HMappable<Poly<F>> for HCons<Head, Tail> {
     type Output = HCons<<F as Func<Head>>::Output, <Tail as HMappable<Poly<F>>>::Output>;
 


### PR DESCRIPTION
This allows you to recursively call `hmap` inside of a `Func::call` implementation